### PR TITLE
Updated package.json to correspond to the new repo url

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/naoufal/unsplash.git"
+    "url": "git+https://github.com/naoufal/unsplash-js.git"
   },
   "keywords": [
     "unsplash",
@@ -32,9 +32,9 @@
   "author": "Naoufal Kadhom",
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/naoufal/unsplash/issues"
+    "url": "https://github.com/naoufal/unsplash-js/issues"
   },
-  "homepage": "https://github.com/naoufal/unsplash#readme",
+  "homepage": "https://github.com/naoufal/unsplash-js#readme",
   "devDependencies": {
     "babel": "5.8.29",
     "babel-core": "5.8.32",


### PR DESCRIPTION
I saw that the link to the right on https://www.npmjs.com/package/unsplash-js pointed to the wrong (old?) repo url.