### PR TITLE
Avoid browser caching on ajax request

### DIFF
--- a/README.md
+++ b/README.md
@@ -340,19 +340,19 @@ unsplash.photos.getPhoto("mtNweauBsMQ", 1920, 1080, [0, 0, 1920, 1080])
 ```
 ---
 
-### photos.getRandomPhoto(category, featured, username, query, width, height)
+### photos.getRandomPhoto(width, height, query, username, featured, category)
 Retrieve a single random photo, given optional filters.
 
 __Arguments__
 
 | Argument | Type | Opt/Required |
 |---|---|---|
-|__`category`__|_Array<number>_|Optional|
-|__`featured`__|_boolean_|Optional|
-|__`username`__|_string_|Optional|
-|__`query`__|_string_|Optional|
 |__`width`__|_number_|Optional|
 |__`height`__|_number_|Optional|
+|__`query`__|_string_|Optional|
+|__`username`__|_string_|Optional|
+|__`featured`__|_boolean_|Optional|
+|__`category`__|_Array<number>_|Optional|
 
 __Example__
 ```js

--- a/src/methods/photos.js
+++ b/src/methods/photos.js
@@ -52,7 +52,7 @@ export default function photos(): Object {
       });
     },
 
-    getRandomPhoto: (width, height, q, username, featured, category, dateTime = new Date().getTime()) => {
+    getRandomPhoto: (width, height, q, username, featured, category, cacheBuster = new Date().getTime()) => {
       const url = "/photos/random";
 
       let query = {
@@ -62,7 +62,7 @@ export default function photos(): Object {
         query: q,
         w: width,
         h: height,
-        _: dateTime // Avoid ajax response caching
+        cacheBuster: cacheBuster // Avoid ajax response caching
       };
 
       return this.request({

--- a/src/methods/photos.js
+++ b/src/methods/photos.js
@@ -52,7 +52,7 @@ export default function photos(): Object {
       });
     },
 
-    getRandomPhoto: (width, height, q, username, featured, category) => {
+    getRandomPhoto: (width, height, q, username, featured, category, dateTime = new Date().getTime()) => {
       const url = "/photos/random";
 
       let query = {
@@ -61,7 +61,8 @@ export default function photos(): Object {
         username,
         query: q,
         w: width,
-        h: height
+        h: height,
+        _: dateTime // Avoid ajax response caching
       };
 
       return this.request({

--- a/src/methods/photos.js
+++ b/src/methods/photos.js
@@ -62,7 +62,7 @@ export default function photos(): Object {
         query: q,
         w: width,
         h: height,
-        cacheBuster: cacheBuster // Avoid ajax response caching
+        cacheBuster // Avoid ajax response caching
       };
 
       return this.request({

--- a/test/unsplash-test.js
+++ b/test/unsplash-test.js
@@ -342,6 +342,7 @@ describe("Unsplash", () => {
             query: undefined,
             w: undefined,
             h: undefined
+            _: undefined
           }
         }]);
       });

--- a/test/unsplash-test.js
+++ b/test/unsplash-test.js
@@ -329,19 +329,19 @@ describe("Unsplash", () => {
     describe("getRandomPhoto", () => {
       it("should make a GET request to /photos/random", () => {
         let spy = spyOn(unsplash, "request");
-        unsplash.photos.getRandomPhoto(undefined,undefined,undefined,undefined,undefined,undefined, 123);
+        unsplash.photos.getRandomPhoto(null, null, null, null, null, null, 123);
 
         expect(spy.calls.length).toEqual(1);
         expect(spy.calls[0].arguments).toEqual([{
           method: "GET",
           url: "/photos/random",
           query: {
-            category: undefined,
-            featured: undefined,
-            username: undefined,
-            query: undefined,
-            w: undefined,
-            h: undefined,
+            category: null,
+            featured: null,
+            username: null,
+            query: null,
+            w: null,
+            h: null,
             cacheBuster: 123
           }
         }]);

--- a/test/unsplash-test.js
+++ b/test/unsplash-test.js
@@ -329,7 +329,7 @@ describe("Unsplash", () => {
     describe("getRandomPhoto", () => {
       it("should make a GET request to /photos/random", () => {
         let spy = spyOn(unsplash, "request");
-        unsplash.photos.getRandomPhoto();
+        unsplash.photos.getRandomPhoto(undefined,undefined,undefined,undefined,undefined,undefined, 123);
 
         expect(spy.calls.length).toEqual(1);
         expect(spy.calls[0].arguments).toEqual([{
@@ -341,8 +341,8 @@ describe("Unsplash", () => {
             username: undefined,
             query: undefined,
             w: undefined,
-            h: undefined
-            _: undefined
+            h: undefined,
+            cacheBuster: 123
           }
         }]);
       });


### PR DESCRIPTION
By default, all the response on GET resquest are cached by the browser.
This cause issue with the random endpoint, since we want a different photo at every call.
To fix this issue, a new parameter is passed to the request with the timestamp of the request.