### PR TITLE
Add custom api version and url

### DIFF
--- a/src/unsplash.js
+++ b/src/unsplash.js
@@ -31,9 +31,18 @@ export default class Unsplash {
   stats: Object;
   toJson: Function;
 
-  constructor(options: { applicationId: string, secret: string, callbackUrl: string, bearerToken?: string }) {
-    this._apiUrl = API_URL;
-    this._apiVersion = API_VERSION;
+  constructor(
+    options: {
+      apiUrl: string,
+      apiVersion: string,
+      applicationId: string,
+      secret: string,
+      callbackUrl: string,
+      bearerToken?: string
+    }
+  ) {
+    this._apiUrl = options.apiUrl || API_URL;
+    this._apiVersion = options.apiVersion || API_VERSION;
     this._applicationId = options.applicationId;
     this._secret = options.secret;
     this._callbackUrl = options.callbackUrl;

--- a/test/unsplash-test.js
+++ b/test/unsplash-test.js
@@ -14,7 +14,7 @@ describe("Unsplash", () => {
   mockery.registerMock("fetch", () => {});
 
   describe("constructor", () => {
-    let unsplash = new Unsplash({
+    const unsplash = new Unsplash({
       applicationId,
       secret,
       callbackUrl
@@ -66,6 +66,30 @@ describe("Unsplash", () => {
 
     it("should have a stats method", () => {
       expect(unsplash.stats).toExist();
+    });
+
+    it("should overwrite the api url", () => {
+      const apiUrl = "http://foo.com";
+      const unsplash = new Unsplash({
+        applicationId,
+        secret,
+        apiUrl,
+        callbackUrl
+      });
+
+      expect(unsplash._apiUrl).toBe(apiUrl);
+    });
+
+    it("should overwrite the api version", () => {
+      const apiVersion = "v8";
+      const unsplash = new Unsplash({
+        applicationId,
+        secret,
+        apiVersion,
+        callbackUrl
+      });
+
+      expect(unsplash._apiVersion).toBe(apiVersion);
     });
   });
 


### PR DESCRIPTION
## Overview
- Adds custom `apiUrl`/`apiVersion` support.
- This is useful for when you want to proxy requests or local development